### PR TITLE
Allow default settings to over overrriden on component.

### DIFF
--- a/Controller/Component/InputComponent.php
+++ b/Controller/Component/InputComponent.php
@@ -64,8 +64,8 @@ class InputComponent extends Component {
 	 */
 	public function __construct(ComponentCollection $collection, $settings = array()) {
 		$settings = Hash::merge(
-			$settings,
-			['settings' => $this->defaults]
+			['settings' => $this->defaults],
+			$settings
 		);
 		parent::__construct($collection, $settings);
 


### PR DESCRIPTION
The component accepts settings from individual controllers but will overwrite them with its own default settings. So auto-clean was being to set true in all cases. This just changes the order of the array merge so that passed in settings will overwrite the default ones.

Shouldn't impact much, as a search of the code base shows almost no controllers explicitly passing settings to this component.